### PR TITLE
Support Set instance for "values" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ Validator object constructor. Accepts validation template, an object in the foll
 ```
 {
   type: '<type>',
-  missing: '<ignore>|<default>', //optional
-  extra: '<ignore>', //optional
+  missing: 'ignore'|'default', //optional
+  extra: 'ignore', //optional
   default: '<default_value>', //required if 'missing' is specified
-  values: [], //optional, a set of values allowed for this object
+  values: []|Set, //optional, an array or set of values allowed for this object
   validate: (TEMPLATE, data, path, options) => {}, //optional, a custom validation function
   transformBefore: (data) => {}, //optional, a custom function to transform the object before any validation
   transformAfter: (data) => {}, //optional, a custom function to transform the object after validation

--- a/lib/index.js
+++ b/lib/index.js
@@ -292,7 +292,11 @@ function validateInternal(TEMPLATE, data, path, options) {
     throw new IamValidatorError(CODES.NO_VALIDATOR, { path: path });
   }
 
-  if (Array.isArray(TEMPLATE.values)) {
+  if (TEMPLATE.values instanceof Set) {
+    if (!TEMPLATE.values.has(data)) {
+      throw new IamValidatorError(TEMPLATE.errorCode || CODES.NOT_IN_VALUES, { path: path, src: data });
+    }
+  } else if (Array.isArray(TEMPLATE.values)) {
     const inValues = _.any(TEMPLATE.values, elem => {
       return _.isEqual(elem, data);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iamvalidator",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "JS object validator",
   "main": "lib/index.js",
   "author": "IamProject Node.js team",

--- a/test/index.js
+++ b/test/index.js
@@ -395,6 +395,33 @@ describe('validator', () => {
       path: '_root.fruit',
       src: 'carrot'
     });
+    itOk('6.1. Returns the value when it\'s in \'values\' set option', {
+      type: 'object',
+      fields: {
+        fruit: {
+          type: 'string',
+          values: new Set(['apple', 'orange', 'banana'])
+        }
+      }
+    }, {
+      fruit: 'orange'
+    }, {
+      fruit: 'orange'
+    });
+    itFail('6.2. Throws "NOT_IN_VALUES" when it\'s not in \'values\' set option', {
+      type: 'object',
+      fields: {
+        fruit: {
+          type: 'string',
+          values: new Set(['apple', 'orange', 'banana'])
+        }
+      }
+    }, {
+      fruit: 'carrot'
+    }, 'NOT_IN_VALUES', {
+      path: '_root.fruit',
+      src: 'carrot'
+    });
   });
 
   describe('7. Arrays', () => {


### PR DESCRIPTION
That increases performance when passing many items in `values` template parameter.

Here is the benchmark:

```
const COUNT = 50;
// Results for COUNT=2 (simplest case) are almost equal
// Results for COUNT=20 differ by 2 times
// Results for COUNT=50 differ by 5 times
// Results for Set are almost equal, no matter the value of COUNT
// Results for Array grow linearly

const ITERATIONS = 1000 * 1000;
const I = (Math.floor(COUNT / 2) - 1).toString();

const array = [];
const set = new Set();

for (let i = 0; i < COUNT; ++i) {
  array.push(i.toString());
  set.add(i.toString());
}

let xa;
let xs;

console.time('array');

for (let i = 0; i < ITERATIONS; ++i) {
  xa = array.includes(I);
}

console.timeEnd('array');

console.time('set');

for (let i = 0; i < ITERATIONS; ++i) {
  if (set instanceof Set) { // We should take into account that additional type checking is not for free
    xs = set.has(I);
  }
}

console.timeEnd('set');

console.log(xa, xs); // To ensure the values are used and no optimisations are applied
```